### PR TITLE
Configure cargo-deny version with an organization secret

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -18,11 +18,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Fetch cargo-audit
+      - name: Setup cargo-deny
         run: |
-          curl -sL "$RELEASE" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
+          version=${RELEASE_VERSION#"version="}
+          cargo_deny_tarball="$RELEASE_BASE/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          echo "Downloading cargo-deny $version from $cargo_deny_tarball."
+          curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
         env:
-          RELEASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.6.8/cargo-deny-0.6.8-x86_64-unknown-linux-musl.tar.gz"
+          RELEASE_BASE: "https://github.com/EmbarkStudios/cargo-deny/releases/download"
+          RELEASE_VERSION: ${{ secrets.CARGO_DENY_VERSION }}
+
+      - name: cargo-deny version
+        run: cargo-deny --version
 
       - name: Run cargo-deny
-        run: cargo-deny check
+        run: cargo-deny check --show-stats


### PR DESCRIPTION
Intend to use this same setup and execute block in all Rust
repositories, which will allow keeping the cargo-deny version in sync by
updating a single secret.

See artichoke/rand_mt#44.