### PR TITLE
Update Rakefile to pull in improvements from Artichoke

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "img.shields.io"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [
+    {
+      "urls": ["https://crates.io"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,16 @@ jobs:
       - name: Lint and check formatting with Rubocop
         run: bundle exec rubocop
 
+  c:
+    name: Lint and format C
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Lint and check formatting with clang-format
+        run: npx github:artichoke/clang-format --check include
+
   text:
     name: Lint and format text
     runs-on: ubuntu-latest

--- a/Rakefile
+++ b/Rakefile
@@ -1,64 +1,125 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require 'shellwords'
+require 'rubocop/rake_task'
 
-task default: :lint
+task default: %i[format lint]
 
-desc 'Lint and format'
-task lint: %i[lint:format lint:clippy lint:rubocop]
+desc 'Lint sources'
+task lint: %i[lint:clippy lint:rubocop:auto_correct]
 
 namespace :lint do
-  desc 'Run Clippy'
+  RuboCop::RakeTask.new(:rubocop)
+
+  desc 'Lint Rust sources with Clippy'
   task :clippy do
-    roots = Dir.glob('**/{build,lib,main}.rs')
-    roots.each do |root|
+    FileList['**/{build,lib,main}.rs'].each do |root|
       FileUtils.touch(root)
     end
-    sh 'cargo clippy'
+    sh 'cargo clippy --workspace --all-features'
   end
 
-  desc 'Run RuboCop'
-  task :rubocop do
-    sh 'rubocop -a'
+  desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'
+  task :'clippy:restriction' do
+    FileList['**/{build,lib,main}.rs'].each do |root|
+      FileUtils.touch(root)
+    end
+    lints = [
+      'clippy::dbg_macro',
+      'clippy::get_unwrap',
+      'clippy::indexing_slicing',
+      'clippy::panic',
+      'clippy::print_stdout',
+      'clippy::expect_used',
+      'clippy::unwrap_used',
+      'clippy::todo',
+      'clippy::unimplemented',
+      'clippy::unreachable'
+    ]
+    command = ['cargo', 'clippy', '--'] + lints.flat_map { |lint| ['-W', lint] }
+    sh command.shelljoin
   end
+end
 
-  desc 'Format sources'
-  task :format do
+desc 'Format sources'
+task format: %i[format:rust format:text format:c]
+
+namespace :format do
+  desc 'Format Rust sources with rustfmt'
+  task :rust do
     sh 'cargo fmt -- --color=auto'
+  end
+
+  desc 'Format text, YAML, and Markdown sources with prettier'
+  task :text do
     sh "npx prettier --write '**/*'"
   end
 
-  desc 'Lint with Clippy restriction pass (unenforced lints)'
-  task :restriction do
-    sh 'cargo clippy -- ' \
-      '-W clippy::dbg_macro ' \
-      '-W clippy::get_unwrap ' \
-      '-W clippy::indexing_slicing ' \
-      '-W clippy::option_expect_used ' \
-      '-W clippy::option_unwrap_used ' \
-      '-W clippy::panic ' \
-      '-W clippy::print_stdout ' \
-      '-W clippy::result_expect_used ' \
-      '-W clippy::result_unwrap_used ' \
-      '-W clippy::todo ' \
-      '-W clippy::unimplemented ' \
-      '-W clippy::unreachable'
+  desc 'Format .c and .h sources with clang-format'
+  task :c do
+    sh 'npx github:artichoke/clang-format include'
   end
+end
+
+desc 'Format sources'
+task fmt: %i[fmt:rust fmt:text fmt:c]
+
+namespace :fmt do
+  desc 'Format Rust sources with rustfmt'
+  task :rust do
+    sh 'cargo fmt -- --color=auto'
+  end
+
+  desc 'Format text, YAML, and Markdown sources with prettier'
+  task :text do
+    sh "npx prettier --write '**/*'"
+  end
+
+  desc 'Format .c and .h sources with clang-format'
+  task :c do
+    sh 'npx github:artichoke/clang-format include'
+  end
+end
+
+desc 'Build Rust workspace'
+task :build do
+  sh 'cargo build --workspace'
 end
 
 desc 'Generate Rust API documentation'
 task :doc do
-  ENV['RUSTDOCFLAGS'] = '-D warnings'
-  sh 'rustup run --install nightly cargo doc --workspace --no-deps'
+  ENV['RUSTFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
+  sh 'rustup run --install nightly cargo doc --workspace'
 end
 
 desc 'Generate Rust API documentation and open it in a web browser'
 task :'doc:open' do
-  ENV['RUSTDOCFLAGS'] = '-D warnings'
-  sh 'rustup run --install nightly cargo doc --workspace --no-deps --open'
+  ENV['RUSTFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
+  sh 'rustup run --install nightly cargo doc --workspace --open'
 end
 
-desc 'Run Artichoke unit tests'
+desc 'Run Strudel unit tests'
 task :test do
   sh 'cargo test --workspace'
+end
+
+namespace :release do
+  link_check_files = FileList.new('**/*.md') do |f|
+    f.exclude('node_modules/**/*')
+    f.exclude('**/target/**/*')
+    f.exclude('**/vendor/**/*')
+    f.include('*.md')
+    f.include('**/vendor/*.md')
+  end
+
+  link_check_files.sort.uniq.each do |markdown|
+    desc 'Check for broken links in markdown files'
+    task markdown_link_check: markdown do
+      command = ['npx', 'markdown-link-check', '--config', '.github/markdown-link-check.json', markdown]
+      sh command.shelljoin
+      sleep(rand(1..5))
+    end
+  end
 end


### PR DESCRIPTION
- Add markdown link check task.
- Set RUSTFLAGS and RUSTDOCFLAGS when building docs.
- Add top-level fmt and format namespaces.
- Use rubocop-provided Rake task.
- Add clippy:restriction lint pass.
- Use FileList API instead of Dir.glob.