### PR TITLE
Add RuboCop GitHub error formatter to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
         run: bundle install
 
       - name: Lint and check formatting with Rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop --format github
 
   c:
     name: Lint and format C


### PR DESCRIPTION
Introduced with bump to RuboCop 1.2.0 in #20.