### PR TITLE
Add apt-get update before installing gcc-multilib

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install 32-bit platform support
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install gcc-multilib
+        run: sudo apt-get update && sudo apt install gcc-multilib
 
       - name: Compile
         run: cargo build --verbose --target ${{ matrix.target }}


### PR DESCRIPTION
Builds are flaking on the _Install 32-bit platform support_ build step which does:

```shell
sudo apt install gcc-multilib
```