### PR TITLE
Add a default cargo-deny version to the audit CI job

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup cargo-deny
         run: |
           version=${RELEASE_VERSION#"version="}
+          version=${version:-"0.8.5"}
           cargo_deny_tarball="$RELEASE_BASE/$version/cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
           echo "Downloading cargo-deny $version from $cargo_deny_tarball."
           curl -sL "$cargo_deny_tarball" | sudo tar xvz -C /usr/local/bin/ --strip-components=1


### PR DESCRIPTION
The `cargo-deny` version is injected into the `audit` GitHub Actions
workflow using an organization secret. This means that PRs from GitHub
users that are not part of the @artichoke organization do not have
access to the version and the subsequent fetch of the release assets
fails.

This PR adds a fallback version for `cargo-deny` which is set if
`$version` is empty.

This change allows PRs from external contributors to build all green.