### PR TITLE
Fix devtools to work on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,11 +8,12 @@ AllCops:
     - "**/node_modules/**/*"
     - "**/target/**/*"
     - "**/vendor/**/*"
+Layout/EndOfLine:
+  EnforcedStyle: lf
 Layout/LineLength:
   Enabled: true
   Exclude:
     - "**/Rakefile"
-    - "**/extn/**/*"
 Metrics:
   Enabled: false
 Style/CombinableLoops:

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 
   desc 'Format .c and .h sources with clang-format'
@@ -72,7 +72,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 
   desc 'Format .c and .h sources with clang-format'


### PR DESCRIPTION
- Force unix-style line endings on Windows with RuboCop.
- Fix prettier glob quoting to work  on Windows in `package.json` run script and `Rakefile`.