### PR TITLE
Address clippy lint violations in Rsut 1.54.0

### DIFF
--- a/src/api/hasher.rs
+++ b/src/api/hasher.rs
@@ -94,7 +94,7 @@ impl Hasher for StHasher {
     fn write(&mut self, bytes: &[u8]) {
         let mut iter = bytes.chunks_exact(size_of::<st_hash_t>());
         let mut buf = [0_u8; size_of::<st_hash_t>()];
-        while let Some(chunk) = iter.next() {
+        for chunk in &mut iter {
             buf.copy_from_slice(chunk);
             let i = st_hash_t::from_ne_bytes(buf);
             self.add_to_hash(i);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -679,7 +679,7 @@ pub unsafe fn st_add_direct(table: *mut st_table, key: st_data_t, value: st_data
 #[inline]
 pub unsafe fn st_free_table(table: *mut st_table) {
     let table = st_table::from_raw(table);
-    drop(table)
+    drop(table);
 }
 
 /// No-op. See comments for function [`st_delete_safe`].

--- a/src/api/typedefs.rs
+++ b/src/api/typedefs.rs
@@ -169,7 +169,7 @@ impl ExternStHashMap {
         // `StHashMap` assumes `cmp` is a valid non-NULL function pointer.
         let eq = unsafe { (*hash_type).compare };
         let key = ExternKey { record: key, eq };
-        self.update(key, value)
+        self.update(key, value);
     }
 
     /// Wrapper around [`StHashMap::remove`] that wraps a bare `st_data_t` in a

--- a/src/capi/mod.rs
+++ b/src/capi/mod.rs
@@ -303,7 +303,7 @@ unsafe extern "C" fn st_add_direct(table: *mut st_table, key: st_data_t, value: 
     #[cfg(feature = "debug")]
     dbg!("st_add_direct");
 
-    api::st_add_direct(table, key, value)
+    api::st_add_direct(table, key, value);
 }
 
 /// # Header declaration
@@ -322,7 +322,7 @@ unsafe extern "C" fn st_add_direct_with_hash(
     #[cfg(feature = "debug")]
     dbg!("st_add_direct_with_hash");
 
-    api::st_add_direct(table, key, value)
+    api::st_add_direct(table, key, value);
 }
 
 /// # Header declaration
@@ -335,7 +335,7 @@ unsafe extern "C" fn st_free_table(table: *mut st_table) {
     #[cfg(feature = "debug")]
     dbg!("st_free_table");
 
-    api::st_free_table(table)
+    api::st_free_table(table);
 }
 
 /// # Header declaration
@@ -348,7 +348,7 @@ unsafe extern "C" fn st_cleanup_safe(table: *mut st_table, never: st_data_t) {
     #[cfg(feature = "debug")]
     dbg!("st_cleanup_safe");
 
-    api::st_cleanup_safe(table, never)
+    api::st_cleanup_safe(table, never);
 }
 
 /// # Header declaration
@@ -361,7 +361,7 @@ unsafe extern "C" fn st_clear(table: *mut st_table) {
     #[cfg(feature = "debug")]
     dbg!("St_clear");
 
-    api::st_clear(table)
+    api::st_clear(table);
 }
 
 /// # Header declaration


### PR DESCRIPTION
- `semicolon_if_nothing_returned`
- `while_let_on_iterator`