### PR TITLE
Add GitHub Actions workflow to run markdown-link-check

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "img.shields.io"
+    },
+    {
+      "pattern": "^https://docs.rs/strudel$"
     }
   ],
   "replacementPatterns": [],

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,32 @@
+---
+"on":
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  schedule:
+    - cron: "0 0 * * TUE"
+name: Markdown Links Check
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from /docs including all subfolders
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/markdown-link-check.json"
+          folder-path: "."

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 <br>
 [![Crate](https://img.shields.io/crates/v/strudel.svg)](https://crates.io/crates/strudel)
+<!-- markdown-link-check-disable-next-line -->
 [![API](https://docs.rs/strudel/badge.svg)](https://docs.rs/strudel)
 [![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/strudel/strudel/)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 <br>
 [![Crate](https://img.shields.io/crates/v/strudel.svg)](https://crates.io/crates/strudel)
-<!-- markdown-link-check-disable-next-line -->
 [![API](https://docs.rs/strudel/badge.svg)](https://docs.rs/strudel)
 [![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/strudel/strudel/)
 

--- a/Rakefile
+++ b/Rakefile
@@ -103,6 +103,7 @@ Bundler::Audit::Task.new
 namespace :release do
   link_check_files = FileList.new('**/*.md') do |f|
     f.exclude('node_modules/**/*')
+    f.exclude('**/build/**/*')
     f.exclude('**/target/**/*')
     f.exclude('**/vendor/**/*')
     f.include('*.md')


### PR DESCRIPTION
Artichoke already incorporates this tool in the `Rakefile` as the
`release:markdown_link_check` task, but it is slow and doesn't get
regularly run.

Incorporate this into CI such that links are checked on every PR that
touches markdown files and on a weekly cron with the same cadence as the
audit workflow.

This PR also includes a disable pragma in README.md because `strudel` is not yet published to crates.io and also adds an additional exclude dir in the `Rakefile` task definition.