### PR TITLE
Update Cargo.toml manifest version and docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,7 @@ readme = "README.md"
 license = "MIT"
 keywords = ["hash", "hashtable", "ffi", "port"]
 categories = ["api-bindings", "data-structures", "external-ffi-bindings"]
-include = [
-  "**/*.rs",
-  "LICENSE",
-  "README.md"
-]
-
-[dependencies]
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [workspace]
 members = [
@@ -25,3 +19,12 @@ members = [
 [profile.release]
 codegen-units = 1
 lto = true
+
+[dependencies]
+
+[package.metadata.docs.rs]
+# This sets the default target to `x86_64-unknown-linux-gnu` and only builds
+# that target. `strudel` has the same API and code on all targets.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,12 @@ rewritten by Vladimir Makarov <vmakarov@redhat.com>.  */
 #![warn(rust_2018_idioms)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
-#![allow(non_camel_case_types)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! Insertion-ordered hash table suitable for embedding via FFI.
 //!

--- a/strudel-ffi/Cargo.toml
+++ b/strudel-ffi/Cargo.toml
@@ -9,20 +9,23 @@ readme = "README.md"
 license = "MIT"
 keywords = ["hash", "hashtable", "ffi", "port"]
 categories = ["api-bindings", "data-structures", "external-ffi-bindings"]
-include = [
-  "**/*.rs",
-  "LICENSE",
-  "README.md"
-]
+include = ["src/**/*", "LICENSE", "README.md"]
 
 [lib]
 crate-type = ["cdylib"]
 name = "strudel_st"
 
 [dependencies]
-fnv = "1.0"
-libc = "0.2"
-strudel = { version = "1.0", path = ".." }
+fnv = "1.0.7"
+libc = "0.2.118"
+strudel = { version = "=1.0.0", path = ".." }
 
 [dev-dependencies]
-memoffset = "0.6"
+memoffset = "0.6.5"
+
+[package.metadata.docs.rs]
+# This sets the default target to `x86_64-unknown-linux-gnu` and only builds
+# that target. `strudel-ffi` has the same API and code on all targets.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+rustdoc-args = ["--cfg", "docsrs"]

--- a/strudel-ffi/src/lib.rs
+++ b/strudel-ffi/src/lib.rs
@@ -114,6 +114,12 @@ rewritten by Vladimir Makarov <vmakarov@redhat.com>.  */
 #![warn(rust_2018_idioms)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 mod bindings;
 mod ffi;


### PR DESCRIPTION
- Use precise versions for dependencies. See: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277
- Use the same style of docs.rs metadata as used in artichoke/raw-parts#24.
- Enable `doc_cfg` and `doc_alias` features when `docsrs` cfg is passed during compilation.

See:

- https://github.com/artichoke/rand_mt/pull/125