### PR TITLE
Address clippy lint violations on Rust 1.62.0

### DIFF
--- a/src/st/map/iter.rs
+++ b/src/st/map/iter.rs
@@ -193,7 +193,7 @@ impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
 #[derive(Debug, Clone)]
 pub struct InsertRanks(pub(crate) Range<usize>);
 
-impl<'a> Iterator for InsertRanks {
+impl Iterator for InsertRanks {
     type Item = usize;
 
     #[inline]
@@ -227,11 +227,11 @@ impl<'a> Iterator for InsertRanks {
     }
 }
 
-impl<'a> FusedIterator for InsertRanks {}
+impl FusedIterator for InsertRanks {}
 
-impl<'a> ExactSizeIterator for InsertRanks {}
+impl ExactSizeIterator for InsertRanks {}
 
-impl<'a> DoubleEndedIterator for InsertRanks {
+impl DoubleEndedIterator for InsertRanks {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
     }

--- a/src/st/set/iter.rs
+++ b/src/st/set/iter.rs
@@ -117,7 +117,7 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 #[derive(Debug)]
 pub struct InsertRanks(pub(crate) map::InsertRanks);
 
-impl<'a> Iterator for InsertRanks {
+impl Iterator for InsertRanks {
     type Item = usize;
 
     #[inline]
@@ -151,11 +151,11 @@ impl<'a> Iterator for InsertRanks {
     }
 }
 
-impl<'a> FusedIterator for InsertRanks {}
+impl FusedIterator for InsertRanks {}
 
-impl<'a> ExactSizeIterator for InsertRanks {}
+impl ExactSizeIterator for InsertRanks {}
 
-impl<'a> DoubleEndedIterator for InsertRanks {
+impl DoubleEndedIterator for InsertRanks {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
     }


### PR DESCRIPTION
Addresses build failures in #117, #118.