### PR TITLE
Rename `clippy::let_underscore_drop` lint to `let_underscore_drop`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ rewritten by Vladimir Makarov <vmakarov@redhat.com>.  */
 #![warn(clippy::cargo)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::let_underscore_drop)]
+#![allow(let_underscore_drop)]
 #![allow(unknown_lints)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]

--- a/strudel-ffi/src/lib.rs
+++ b/strudel-ffi/src/lib.rs
@@ -105,7 +105,7 @@ rewritten by Vladimir Makarov <vmakarov@redhat.com>.  */
 #![warn(clippy::cargo)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::let_underscore_drop)]
+#![allow(let_underscore_drop)]
 #![allow(unknown_lints)]
 #![warn(missing_debug_implementations)]
 // #![warn(missing_docs)]


### PR DESCRIPTION
This lint was upstreamed to rustc in Rust 1.67.0.

See CI run: https://github.com/artichoke/strudel/actions/runs/4059577056/jobs/6987775040

```
Updating crates.io index
 Downloading crates ...
  Downloaded autocfg v1.1.0
  Downloaded fnv v1.0.7
  Downloaded memoffset v0.8.0
  Downloaded libc v0.2.13[9](https://github.com/artichoke/strudel/actions/runs/4059577056/jobs/6987775040#step:5:10)
   Compiling autocfg v1.1.0
   Compiling libc v0.2.139
   Compiling memoffset v0.8.0
    Checking strudel v1.0.0 (/home/runner/work/strudel/strudel)
error: lint `clippy::let_underscore_drop` has been renamed to `let_underscore_drop`
   --> src/lib.rs:108:10
    |
108 | #![allow(clippy::let_underscore_drop)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `let_underscore_drop`
    |
    = note: `-D renamed-and-removed-lints` implied by `-D warnings`

    Checking fnv v1.0.7
error: could not compile `strudel` due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `strudel` due to previous error
```