### PR TITLE
Update Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,12 +47,12 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh 'npx prettier --write "**/*"'
+    sh 'npm run fmt'
   end
 
   desc 'Format .c and .h sources with clang-format'
   task :c do
-    sh 'npx github:artichoke/clang-format include'
+    sh 'npm run fmt:c'
   end
 end
 
@@ -67,12 +67,12 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh 'npx prettier --write "**/*"'
+    sh 'npm run fmt'
   end
 
   desc 'Format .c and .h sources with clang-format'
   task :c do
-    sh 'npx github:artichoke/clang-format include'
+    sh 'npm run fmt:c'
   end
 end
 


### PR DESCRIPTION
Use `npm run fmt` instead of `npx` to invoke `prettier`.

Use `npm run fmt:c` instead of `npx` to invoke `clang-format`.